### PR TITLE
Update ga_block.view.lkml to correct spelling

### DIFF
--- a/ga_block.view.lkml
+++ b/ga_block.view.lkml
@@ -471,7 +471,7 @@ view: hits_base {
     label: "Is Secure"
     type: yesno
   }
-  dimension: isiInteraction {
+  dimension: isInteraction {
     label: "Is Interaction"
     type: yesno
   }


### PR DESCRIPTION
There's a typo in the dimension referencing hits.isInteraction. It should isInteraction instead of isiInteraction.