### PR TITLE
Support timezone picker on ga_session.visitStart

### DIFF
--- a/ga_block.view.lkml
+++ b/ga_block.view.lkml
@@ -161,7 +161,7 @@ view: ga_sessions_base {
     timeframes: [date,day_of_week,fiscal_quarter,week,month,year,month_name,month_num,week_of_year]
     label: "Visit Start"
     type: time
-    sql: (TIMESTAMP(${visitStartSeconds})) ;;
+    sql: ${visitStartSeconds::datetime} ;;
   }
   ## use visit or hit start time instead
   dimension: date {


### PR DESCRIPTION
Currently (in at least BigQuery), using `TIMESTAMP(${visitStartSeconds})` will trigger a double cast when you pick a non-UTC timezone since `visitStart` treats the datetime it receives from `visitStartSeconds` as a string. Adding an inline type-hint avoids this and gives the desired behavior. 

This is also pointed out in the [LookML documentation](https://docs.looker.com/data-modeling/learning-lookml/sql-and-referring-to-lookml#using_lookml_field_type_references_with_date_fields) (thanks Olivia from DCL for finding it!). 

cc: @ernestoongaro (since you seem to be the most active maintainer 😅)